### PR TITLE
Encapsulated RAG components and Tools within Agentic rag_controller

### DIFF
--- a/api/app/routes.py
+++ b/api/app/routes.py
@@ -3,16 +3,16 @@ from app.services.order_service import get_order_status
 from app.services.product_service import get_product_stock
 from rag.retrieval.vector_store import PineconeVectorStore
 from rag.retrieval.retriever import Retriever
+from rag.agents.agentic_controller import AgenticRAGController
 from langchain_openai import OpenAIEmbeddings
-from langchain.retrievers.document_compressors import CohereRerank
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
-
 api_blueprint = Blueprint('api', __name__)
 
+# === Core Business Endpoints ===
 @api_blueprint.route('/orders/<order_id>', methods=['GET'])
 def order_status(order_id):
     """Get order status by order ID"""
@@ -25,29 +25,35 @@ def product_stock(product_name):
     stock = get_product_stock(product_name)
     return jsonify({"product_name": product_name, "stock": stock})
 
-# --- FastAPI RAG endpoint ---
+
+# === Agentic RAG Endpoint (UPGRADED) ===
+# Initialize once at startup
+vector_store = PineconeVectorStore(index_name="ecommerce-agentic-rag")
+embedder = OpenAIEmbeddings(model="text-embedding-3-large", api_key=os.getenv("OPENAI_API_KEY"))
+retriever = Retriever(vector_store, embedder)
+rag_controller = AgenticRAGController(retriever)  # Full agentic logic
+
+
 @api_blueprint.route('/rag/query', methods=['POST'])
 def rag_query():
-    """Get RAG results for a query"""
+    """Full Agentic RAG: retrieval + tools + generation"""
     data = request.get_json()
     if not data or "query" not in data:
         return jsonify({"error": "Query is required"}), 400
 
     query = data["query"]
-    top_k = data.get("top_k", 5)
-    use_hyde = data.get("use_hyde", False)
-    use_mmr = data.get("use_mmr", False)
-    use_rerank = data.get("use_rerank", False)
-
-    # Initialize RAG components
-    vector_store = PineconeVectorStore(index_name="ecommerce-rag")
-    embedder = OpenAIEmbeddings(model="text-embedding-3-large", api_key=os.getenv("OPENAI_API_KEY"))
-    rerank_fn = None 
-    retriever = Retriever(vector_store, embedder, rerank_fn=rerank_fn)
 
     try:
-        results = retriever.retrieve(query, top_k, use_hyde, use_mmr, use_rerank)
-        formatted_results = [{"text": r["text"], "metadata": r["metadata"]} for r in results]
-        return jsonify({"results": formatted_results})
+        # Use Agentic Controller (includes self-correction RAG + tool calling)
+        result = rag_controller.query(query)
+
+        return jsonify({
+            "answer": result["answer"],
+            "sources": result["sources"],
+            "confidence": result["confidence"],
+            "tool_calls": result.get("tool_calls", []),
+            "hops": result.get("hops", 1),
+            "retrieval_retries": result.get("retrieval_retries", 0)
+        })
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
Removed retriever calling from rag_query() after encapsulating the complete pipeline flow (Retrieval → Self-correction → Augmentation → Tools → Generation) in  Agentic RAG Controller